### PR TITLE
Fixing a problem with Body Parser

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ var path = require('path'),
     ext_libs = {},
     _ = require('lodash'),
     parent = module.parent.parent || module.parent,
+    embedded = !module.parent.parent,
     dirname = path.dirname(parent.filename),
     mockUtils = require("./utils.js")(dirname);
 
@@ -164,8 +165,9 @@ function getMockserver(cfg) {
 
     //loads the libraries passed in the config
     loadExternalLibs(cfg);
-
-    app.use(express.bodyParser());
+    if (!embedded) {
+        app.use(express.bodyParser());
+    }
     app.use(express.logger());
 
     app.configure(function () {

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ var path = require('path'),
     ext_libs = {},
     _ = require('lodash'),
     parent = module.parent.parent || module.parent,
-    embedded = !module.parent.parent,
+    embedded = !!module.parent.parent,
     dirname = path.dirname(parent.filename),
     mockUtils = require("./utils.js")(dirname);
 


### PR DESCRIPTION
There is a problem in embedded Express apps which use body parser, since the approach used by Express changed.

This PR should fix it.
